### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/r-cmd-check.yaml
+++ b/.github/workflows/r-cmd-check.yaml
@@ -20,4 +20,4 @@ jobs:
           tlmgr install \
           mathpazo \
           pgf
-      - uses: uclahs-cds/tool-R-CMD-check-action@stable
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2


### PR DESCRIPTION
This PR updates the `R CMD check` action to its newest `v2` release.
